### PR TITLE
chore(jquery): fix CVE-2020-11023 PF-7562

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sysdig/jquery",
   "title": "jQuery",
   "description": "JavaScript library for DOM operations",
-  "version": "2.2.5-sysdig-patch-pr3-2",
+  "version": "2.2.5-sysdig-patch-pr3-3",
   "main": "dist/jquery.js",
   "homepage": "http://jquery.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sysdig/jquery",
   "title": "jQuery",
   "description": "JavaScript library for DOM operations",
-  "version": "2.2.5-sysdig-patch-pr3-3",
+  "version": "2.2.5-sysdig-patch",
   "main": "dist/jquery.js",
   "homepage": "http://jquery.com",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "jquery",
+  "name": "@sysdig/jquery",
   "title": "jQuery",
   "description": "JavaScript library for DOM operations",
-  "version": "2.2.5-sysdig-patch",
+  "version": "2.2.5-sysdig-patch-pr3",
   "main": "dist/jquery.js",
   "homepage": "http://jquery.com",
   "author": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jquery/jquery.git"
+    "url": "https://github.com/draios/jquery.git"
   },
   "keywords": [
     "jquery",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sysdig/jquery",
   "title": "jQuery",
   "description": "JavaScript library for DOM operations",
-  "version": "2.2.5-sysdig-patch-pr3",
+  "version": "2.2.5-sysdig-patch-pr3-2",
   "main": "dist/jquery.js",
   "homepage": "http://jquery.com",
   "author": {

--- a/src/manipulation.js
+++ b/src/manipulation.js
@@ -26,7 +26,7 @@ define( [
 	dataPriv, dataUser, acceptData ) {
 
 var
-	rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:-]+)[^>]*)\/>/gi,
+	// rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:-]+)[^>]*)\/>/gi,
 
 	// Support: IE 10-11, Edge 10240+
 	// In IE/Edge using regex groups here causes severe slowdowns.
@@ -226,7 +226,7 @@ function remove( elem, selector, keepData ) {
 
 jQuery.extend( {
 	htmlPrefilter: function( html ) {
-		return html.replace( rxhtmlTag, "<$1></$2>" );
+		return html;
 	},
 
 	clone: function( elem, dataAndEvents, deepDataAndEvents ) {

--- a/src/manipulation/support.js
+++ b/src/manipulation/support.js
@@ -26,6 +26,12 @@ define( [
 	// Make sure textarea (and checkbox) defaultValue is properly cloned
 	div.innerHTML = "<textarea>x</textarea>";
 	support.noCloneChecked = !!div.cloneNode( true ).lastChild.defaultValue;
+
+	// Support: IE <=9 only
+ 	// IE <=9 replaces <option> tags with their contents when inserted outside of
+ 	// the select element.
+ 	div.innerHTML = "<option></option>";
+ 	support.option = !!div.lastChild;
 } )();
 
 return support;

--- a/src/manipulation/wrapMap.js
+++ b/src/manipulation/wrapMap.js
@@ -1,10 +1,12 @@
-define( function() {
+define( [
+	"./support"
+], function( support ) {
 
 // We have to close these tags to support XHTML (#13200)
 var wrapMap = {
 
 	// Support: IE9
-	option: [ 1, "<select multiple='multiple'>", "</select>" ],
+	// option: [ 1, "<select multiple='multiple'>", "</select>" ],
 
 	// XHTML parsers do not magically insert elements in the
 	// same way that tag soup parsers do. So we cannot shorten
@@ -22,6 +24,10 @@ wrapMap.optgroup = wrapMap.option;
 
 wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
 wrapMap.th = wrapMap.td;
+
+if ( !support.option ) {
+    wrapMap.optgroup = wrapMap.option = [ 1, "<select multiple='multiple'>", "</select>" ];
+}
 
 return wrapMap;
 } );


### PR DESCRIPTION
### Summary ###

We patched the source branch `2.2-sysdig-patch` with `2.2.5` jquery and the additional fixes addressing the CVE-2020
-11023. I've published `@sysdig/2.2.5-sysdig-patch` and it's being consumed in this PR for `draios/ui` https://github.com/draios/ui/pull/5306

`npm run build` required the following:
- node 6 (used nvm to install locally)
- publish token (acquired from @drosen0)
-  python 2.7
- Xcode (specifically `xcodebuild` that I'm guessing has some variant of a `gcc` compiler required for the `npm install`)

### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
